### PR TITLE
Add dynamic start_url to manifest file for PWA

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -26,6 +26,8 @@ import TermsConsent from '../src/components/TermsConsent';
 import { usePoolCoins } from 'src/rdx/poolCoins/poolCoins.hooks';
 import SEO from '../next-seo.config';
 import Script from 'next/script';
+import { useEffect } from 'react';
+import { getDynamicManifestUrl } from 'utils/url';
 
 let cachedState;
 let addressSearchState;
@@ -47,6 +49,13 @@ declare global {
 }
 
 const App = ({ Component, pageProps, router }: AppProps) => {
+  useEffect(() => {
+    const { locale, pathname } = router;
+    const manifest = document.getElementById('manifest');
+
+    manifest?.setAttribute('href', getDynamicManifestUrl(locale, pathname));
+  }, [router.pathname, router.locale]);
+
   return (
     <>
       <DefaultSeo {...SEO} />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,5 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
+import { getDynamicManifestUrl } from '../utils/url';
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
@@ -9,8 +10,7 @@ export default class MyDocument extends Document {
     try {
       ctx.renderPage = () =>
         originalRenderPage({
-          enhanceApp: (App) => (props) =>
-            sheet.collectStyles(<App {...props} />),
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
         });
 
       const initialProps = await Document.getInitialProps(ctx);
@@ -29,19 +29,13 @@ export default class MyDocument extends Document {
   }
 
   render() {
+    const { locale, page } = this.props.__NEXT_DATA__;
+
     return (
       <Html lang="en">
         <Head>
-          <link
-            rel="preconnect"
-            href="https://static.flexpool.io"
-            prefetch="false"
-          />
-          <link
-            rel="preconnect"
-            href="https://fonts.googleapis.com"
-            prefetch="false"
-          />
+          <link rel="preconnect" href="https://static.flexpool.io" prefetch="false" />
+          <link rel="preconnect" href="https://fonts.googleapis.com" prefetch="false" />
           <link
             rel="preconnect"
             href="https://xtwj9bs7n2j9.statuspage.io"
@@ -51,24 +45,10 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Inter:wght@100;400;500;600;700;800&family=Roboto+Mono:wght@400;500&display=swap"
             rel="stylesheet"
           />
-          <link rel="manifest" href="/manifest.json" />
-          <link
-            rel="apple-touch-icon"
-            sizes="180x180"
-            href="/apple-touch-icon.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="/favicon-32x32.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="/favicon-16x16.png"
-          />
+          <link rel="manifest" href={getDynamicManifestUrl(locale, page)} id="manifest" />
+          <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+          <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+          <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
           <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
           <meta name="apple-mobile-web-app-title" content="Flexpool.io" />
           <meta name="application-name" content="Flexpool.io" />

--- a/pages/api/manifest.tsx
+++ b/pages/api/manifest.tsx
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import manifest from '../../public/manifest.json';
+
+const dynamicManifest = (req: NextApiRequest, res: NextApiResponse) => {
+  const manifestData = {
+    ...manifest,
+    start_url: req?.query?.url || '/',
+  };
+
+  res.status(200).json(manifestData);
+};
+
+export default dynamicManifest;

--- a/utils/url.js
+++ b/utils/url.js
@@ -1,3 +1,12 @@
 export const getLocationSearch = () => {
   return typeof window !== 'undefined' ? window.location.search : '';
 };
+
+export const getDynamicManifestUrl = (locale, page) => {
+  const url = `/api/manifest?url=/${locale + page}`;
+  // On homepages('/') /en-GB , /en-US etc the pathname /en-GB/ needs to get last / trimmed
+  // in order to prompt install app for homepages through the dynamic manifest
+  let trimmedUrl = url;
+  if (url[url.length - 1] === '/') trimmedUrl = url.substring(0, url.length - 1);
+  return trimmedUrl;
+};


### PR DESCRIPTION
Create endpoint ( `/api/manifest?url=[url]`) for dynamic creation of manifest.

_document.js
Nextjs server adds the manifest tag in header with the url query (inside the href) equals to current pathname (locale and route)

_app.tsx
when pathname is changed (locale or route) React will update manifest's href so url query ( `/api/manifest?url=[url]`) will be equal to the new route
